### PR TITLE
beta 7 updates for dnu

### DIFF
--- a/DNX_Pack.xml
+++ b/DNX_Pack.xml
@@ -18,7 +18,7 @@ cd %teamcity.build.workingDir%
 SETLOCAL
 CALL packages\KoreBuild\build\dnvm use default -runtime %mr.Runtime% -arch %mr.Architecture%
 
-dnu pack "%mr.ProjectJson%" --configuration %mr.Configuration% --out "artifacts\%mr.ArtifactsName%" --dependencies
+dnu pack "%mr.ProjectJson%" --configuration %mr.Configuration% --out "artifacts\%mr.ArtifactsName%"
 
 @echo on
 echo "##teamcity[publishArtifacts 'artifacts\%mr.ArtifactsName% => %mr.ArtifactsName%.zip']"]]></param>

--- a/DNX_TestAll.xml
+++ b/DNX_TestAll.xml
@@ -14,7 +14,7 @@
 cd %teamcity.build.workingDir%
 SETLOCAL
 CALL packages\KoreBuild\build\dnvm use default -runtime %mr.Runtime% -arch %mr.Architecture%
-@powershell -NoProfile -ExecutionPolicy unrestricted -Command "Get-ChildItem %mr.SourceFolder% project.json -rec -erroraction 'silentlycontinue' | Where-Object { $_.FullName -like '*test*' } | Select-Object -Expand DirectoryName | Foreach { cmd /C cd $_ `&`& dnx . test -teamcity }; exit $Lastexitcode"]]></param>
+@powershell -NoProfile -ExecutionPolicy unrestricted -Command "Get-ChildItem %mr.SourceFolder% project.json -rec -erroraction 'silentlycontinue' | Where-Object { $_.FullName -like '*test*' } | Select-Object -Expand DirectoryName | Foreach { cmd /C cd $_ `&`& dnx test -teamcity }; exit $Lastexitcode"]]></param>
           <param name="teamcity.step.mode" value="execute_if_failed" />
           <param name="use.custom.script" value="true" />
         </parameters>

--- a/DNX_TestOne.xml
+++ b/DNX_TestOne.xml
@@ -16,7 +16,7 @@ cd %teamcity.build.workingDir%
 SETLOCAL
 CALL packages\KoreBuild\build\dnvm use default -runtime %mr.Runtime% -arch %mr.Architecture%
 cd "%mr.TestDirectory%"
-CALL dnx . test -teamcity]]></param>
+CALL dnx test -teamcity]]></param>
           <param name="teamcity.step.mode" value="default" />
           <param name="use.custom.script" value="true" />
         </parameters>

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## installations
 
-Place xml files in %TEAMCITY%\config\projects\%Project%\pluginData\metaRunners (C:\ProgramData\JetBrains\TeamCity\config\projects\BaBuildServer\pluginData\metaRunners)
+Place xml files in `%TEAMCITY%\config\projects\%Project%\pluginData\metaRunners` (e.g. `C:\ProgramData\JetBrains\TeamCity\config\projects\BaBuildServer\pluginData\metaRunners`)
 
-## prerequesites
+## prerequisites
 
-If you're using the 'DNX - Install and configure DNX' meta runner, the Build Agent must feature the configuration property %teamcity.tool.nuget% 
+If you're using the 'DNX - Install and configure DNX' meta runner, the Build Agent must feature the configuration property `%teamcity.tool.nuget%`
 pointing to the directory that contains the nuget.exe.
 
 ## attribution


### PR DESCRIPTION
In the current version of DNU, calls are made with `dnu <command>` instead of `dnu <path> <command>`. I updated the runners so that the Unit Test ones work correctly and updated the `README.md`.
